### PR TITLE
fix: accept any type for prestadores

### DIFF
--- a/src/DidiServerApiClient.ts
+++ b/src/DidiServerApiClient.ts
@@ -56,18 +56,7 @@ const responseCodecs = {
 
 	issuerName: t.string,
 
-	semillasPrestadores: t.array(
-		t.type({
-			id: t.number,
-			benefit: t.number,
-			category: t.union([t.string, t.undefined]),
-			email: t.string,
-			name: t.string,
-			whatsappNumber: t.string,
-			phone: t.string,
-			speciality: t.union([t.string, t.null])
-		})
-	),
+	semillasPrestadores: t.array(t.any),
 
 	dataResponse,
 	messageResponse

--- a/src/model/SemillasTypes.ts
+++ b/src/model/SemillasTypes.ts
@@ -3,12 +3,12 @@ import * as t from "io-ts";
 export interface Prestador {
 	id: number;
 	name: string;
-	benefit: number;
+	benefit?: number;
 	email: string;
 	category?: string;
-	speciality: string | null;
-	phone: string;
-	whatsappNumber: string;
+	speciality?: string;
+	phone?: string;
+	whatsappNumber?: string;
 }
 
 export interface ShareDataRequest {


### PR DESCRIPTION
accept any type of providers data

reason: provider fields change frequently, so SDK will accept any array until it's well defined